### PR TITLE
feat: add arm64 images

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -38,7 +38,7 @@ target "ldap" {
   dockerfile = "Dockerfile"
   context = "."
   target = "ldap"
-  platforms = ["linux/amd64"]
+  platforms = ["linux/amd64", "linux/arm64"]
   tags = [
     "${REGISTRY}/${IMAGE_NAME}:latest",
     notequal("", TAG_NAME) ? "${REGISTRY}/${IMAGE_NAME}:${TAG_NAME}" : ""


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3837

This PR adds the `linux/arm64` image to allow LDAP to run on our `arm64` system