### PR TITLE
chore(pipeline) enable `updatecli` to track dependencies

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,5 +1,5 @@
-buildDockerAndPublishImage('ldap', [
+parallelDockerUpdatecli([
+  imageName: 'ldap',
   automaticSemanticVersioning: true,
-  gitCredentials: 'github-app-infra',
   dockerBakeFile: 'docker-bake.hcl',
 ])


### PR DESCRIPTION
Fixup of #38 