### PR TITLE
chore: separate updatecli to its own pipeline

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,4 +1,4 @@
-buildDockerAndPublishImage('ldap', [ 
+buildDockerAndPublishImage('ldap', [
   automaticSemanticVersioning: true,
   dockerBakeFile: 'docker-bake.hcl',
   ])

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -1,7 +1,7 @@
+---
 github:
-  user: "Jenkins Infra Bot (updatecli)"
-  email: "60776566+jenkins-infra-bot@users.noreply.github.com"
-  username: "jenkins-infra-bot"
+  user: "jenkins-infra-updatecli"
+  email: "178728+jenkins-infra-updatecli[bot]@users.noreply.github.com"
   token: "UPDATECLI_GITHUB_TOKEN"
   branch: "main"
   owner: "jenkins-infra"


### PR DESCRIPTION
This PR separates updatecli to its own pipeline and uses https://github.com/apps/jenkins-infra-updatecli instead of https://github.com/jenkins-infra-bot in updatecli values.

Note: added a comment about targeted architectures so it's clear from reading the Jenkinsfile that both amd64 & arm64 are built.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2778