### PR TITLE
feat(slapd): add 'member' to the list of attributes

### DIFF
--- a/config/slapd.conf
+++ b/config/slapd.conf
@@ -48,15 +48,15 @@ moduleload	back_mdb.so
 #
 # rootdn can always read and write EVERYTHING!
 
-access to attrs=userPassword,shadowLastChange 
+access to attrs=userPassword,shadowLastChange
   by dn=OPENLDAP_ADMIN_DN write
   by dn=cn=accountapp-admin,dc=jenkins-ci,dc=org manage
   by anonymous auth
   by self write
   by * none
 
-access to * 
-  by dn=OPENLDAP_ADMIN_DN write 
+access to *
+  by dn=OPENLDAP_ADMIN_DN write
   by dn=cn=accountapp-admin,dc=jenkins-ci,dc=org manage
   by * read
 
@@ -84,7 +84,7 @@ rootdn	  "OPENLDAP_ADMIN_DN"
 # be avoid.  See slappasswd(8) and slapd.conf(5) for details.
 # Use of strong authentication encouraged.
 rootpw		OPENLDAP_ADMIN_PASSWORD
-# The database directory MUST exist prior to running slapd AND 
+# The database directory MUST exist prior to running slapd AND
 # should only be accessible by the slapd and slap tools.
 # Mode 700 recommended.slapd manuel
 directory	/var/lib/ldap
@@ -96,6 +96,7 @@ index     surname eq,pres,sub
 index     givenname eq,pres,sub
 index     ou eq,pres,sub
 index     uniqueMember eq
+index     member eq,pres
 
 #######################################################################
 # SSL configuration


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3837#issuecomment-2855332373

Tested with https://github.com/jenkins-infra/account-app/blob/main/docker-compose.yaml and the following patch:

```diff
   ldap:
-    image: jenkinsciinfra/ldap:latest
+    build:
+      context: ../docker-ldap
+      target: ldap
```

And imported the latest production LDIF backup (mounted in the `ldap-data` service)

- Before this change: logging in with my production `dduportal` account with success in local accountapp, but not an admin
- After this change: I'm admin!

Did the same with a non-admin user `dduportaltest` in both cases:

- Before this change: logging in with success in local accountapp and not an admin
- After this change: logging in with success in local accountapp and still not an admin

Adding the attribute `member` in the index for both equality and presence is motivated by the logs message we see on `linux/arm64` LDAP containers when logging in with accountapp:

```
ldap-1       | 6818eff6 conn=1015 op=2 SRCH base="dc=jenkins-ci,dc=org" scope=2 deref=3 filter="(&(objectClass=groupOfNames)(member=cn=username,ou=people,dc=jenkins-ci,dc=org))"
ldap-1       | 6818eff6 conn=1015 op=2 SRCH attr=cn
ldap-1       | 6818eff6 <= mdb_equality_candidates: (member) not indexed
```