### PR TITLE
chore(updatecli) track Debian Bookworm version

### DIFF
--- a/updatecli/updatecli.d/debian.yml
+++ b/updatecli/updatecli.d/debian.yml
@@ -1,0 +1,52 @@
+---
+name: Bump Debian Bookworm version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  bookwormLatestVersion:
+    kind: dockerimage
+    name: "Get the latest Debian Bookworm Linux version"
+    spec:
+      image: debian
+      tagfilter: bookworm-*
+      architectures:
+        - linux/amd64
+        - linux/arm64
+      versionfilter:
+        kind: regex
+        pattern: >-
+          bookworm-\d+$
+    transformers:
+      - trimprefix: bookworm-
+
+targets:
+  updateDockerfile:
+    name: "Update the value of the base image (ARG BOOKWORM_TAG) in the Dockerfile"
+    kind: dockerfile
+    sourceid: bookwormLatestVersion
+    spec:
+      file: ./Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "BOOKWORM_TAG"
+    scmid: default
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump Debian Bookworm Linux Version to {{ source "bookwormLatestVersion" }}
+    spec:
+      labels:
+        - dependencies
+        - debian


### PR DESCRIPTION
Following #46 , we now want to track the pinned version to keep the image up to date